### PR TITLE
feat: implement Phase 2 — Refinamento

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,79 @@
+name: Build & Test
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+  release:
+    types: [published]
+
+jobs:
+  # -----------------------------------------------------------------------
+  # Run tests on all platforms
+  # -----------------------------------------------------------------------
+  test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        python-version: ["3.12"]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run tests (headless)
+        env:
+          QT_QPA_PLATFORM: offscreen
+        run: pytest --tb=short -q
+
+  # -----------------------------------------------------------------------
+  # Build Windows distributable (only on push/release)
+  # -----------------------------------------------------------------------
+  build-windows:
+    needs: test
+    runs-on: windows-latest
+    if: github.event_name != 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies + PyInstaller
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pyinstaller
+
+      - name: Build with PyInstaller
+        run: pyinstaller sqlshelf.spec --noconfirm
+
+      - name: Upload build artefact
+        uses: actions/upload-artifact@v4
+        with:
+          name: SQLShelf-windows
+          path: dist/SQLShelf/
+          retention-days: 30
+
+      - name: Attach to release
+        if: github.event_name == 'release'
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: dist/SQLShelf/
+          asset_name: SQLShelf-windows.zip
+          asset_content_type: application/zip

--- a/build_app.ps1
+++ b/build_app.ps1
@@ -1,0 +1,33 @@
+# build_app.ps1 — Build SQLShelf Windows distributable via PyInstaller.
+# Usage: .\build_app.ps1
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+Write-Host "=== SQLShelf — PyInstaller build ===" -ForegroundColor Cyan
+
+# Activate venv if present
+if (Test-Path "venv\Scripts\Activate.ps1") {
+    . "venv\Scripts\Activate.ps1"
+    Write-Host "Activated venv" -ForegroundColor Green
+}
+
+# Ensure PyInstaller is installed
+python -m pip install --quiet pyinstaller
+
+# Clean previous build artefacts
+if (Test-Path "dist") { Remove-Item -Recurse -Force "dist" }
+if (Test-Path "build") { Remove-Item -Recurse -Force "build" }
+
+# Run PyInstaller
+Write-Host "Running PyInstaller…" -ForegroundColor Cyan
+pyinstaller sqlshelf.spec --noconfirm
+
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "PyInstaller failed (exit $LASTEXITCODE)"
+    exit $LASTEXITCODE
+}
+
+Write-Host ""
+Write-Host "Build complete — output: dist\SQLShelf\" -ForegroundColor Green
+Write-Host "Run: dist\SQLShelf\SQLShelf.exe"

--- a/sqlshelf.spec
+++ b/sqlshelf.spec
@@ -1,0 +1,70 @@
+# -*- mode: python ; coding: utf-8 -*-
+# PyInstaller spec for SQLShelf — Windows single-folder build.
+# Run: pyinstaller sqlshelf.spec
+
+from pathlib import Path
+from PyInstaller.utils.hooks import collect_data_files
+
+block_cipher = None
+
+# Include the schema.sql resource shipped inside the package
+datas = [
+    ("sqlshelf/core/schema.sql", "sqlshelf/core"),
+]
+datas += collect_data_files("qt_material")
+
+a = Analysis(
+    ["main.py"],
+    pathex=[str(Path(".").resolve())],
+    binaries=[],
+    datas=datas,
+    hiddenimports=[
+        "PySide6.QtCore",
+        "PySide6.QtGui",
+        "PySide6.QtWidgets",
+        "sqlglot",
+        "yaml",
+        "watchdog.observers",
+        "watchdog.observers.polling",
+        "qt_material",
+    ],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=["tkinter", "matplotlib", "numpy", "scipy"],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+    noarchive=False,
+)
+
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name="SQLShelf",
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    console=False,
+    disable_windowed_traceback=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+    icon=None,
+)
+
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    name="SQLShelf",
+)

--- a/sqlshelf/core/index_db.py
+++ b/sqlshelf/core/index_db.py
@@ -22,7 +22,7 @@ class IndexDB:
     the file-watcher thread can share one instance safely.
     """
 
-    SCHEMA_VERSION = "1"
+    SCHEMA_VERSION = "2"
 
     def __init__(self, project_root: Path) -> None:
         self._project_root = project_root
@@ -45,22 +45,79 @@ class IndexDB:
             row = self._conn.execute(
                 "SELECT name FROM sqlite_master WHERE type='table' AND name='meta'"
             ).fetchone()
-            if row is not None:
-                return
-            schema_sql = (
-                files("sqlshelf.core").joinpath("schema.sql").read_text(encoding="utf-8")
-            )
-            self._conn.executescript(schema_sql)
-            self._conn.execute("BEGIN")
-            self._conn.execute(
-                "INSERT INTO meta (key, value) VALUES ('schema_version', ?)",
-                (self.SCHEMA_VERSION,),
-            )
-            self._conn.execute(
-                "INSERT INTO meta (key, value) VALUES ('project_root', ?)",
-                (str(self._project_root),),
-            )
-            self._conn.execute("COMMIT")
+            if row is None:
+                self._create_fresh_schema()
+            else:
+                version_row = self._conn.execute(
+                    "SELECT value FROM meta WHERE key='schema_version'"
+                ).fetchone()
+                v = version_row[0] if version_row else "1"
+                if not self._is_schema_compatible():
+                    # Schema is too old or corrupted — rebuild cleanly
+                    self._drop_all_tables()
+                    self._create_fresh_schema()
+                elif v == "1":
+                    self._migrate_v1_to_v2()
+
+    def _is_schema_compatible(self) -> bool:
+        """Return True if the queries table has all required columns."""
+        cols = {
+            row[1]
+            for row in self._conn.execute("PRAGMA table_info(queries)").fetchall()
+        }
+        required = {
+            "id", "rel_path", "title", "description", "body",
+            "file_mtime", "file_size", "content_hash",
+            "has_frontmatter", "created_at", "updated_at",
+        }
+        return required.issubset(cols)
+
+    def _drop_all_tables(self) -> None:
+        """Wipe the DB by closing, deleting the file, and reopening it.
+
+        The index is fully regenerable from disk — this is always safe.
+        Deleting the file sidesteps ordering constraints (FK, FTS, triggers).
+        """
+        self._conn.close()
+        if self._db_path.exists():
+            self._db_path.unlink()
+        self._conn = sqlite3.connect(
+            str(self._db_path), check_same_thread=False, isolation_level=None
+        )
+        self._conn.execute("PRAGMA foreign_keys = ON")
+
+    def _create_fresh_schema(self) -> None:
+        schema_sql = (
+            files("sqlshelf.core").joinpath("schema.sql").read_text(encoding="utf-8")
+        )
+        self._conn.executescript(schema_sql)
+        self._conn.execute("BEGIN")
+        self._conn.execute(
+            "INSERT OR IGNORE INTO meta (key, value) VALUES ('schema_version', ?)",
+            (self.SCHEMA_VERSION,),
+        )
+        self._conn.execute(
+            "INSERT OR IGNORE INTO meta (key, value) VALUES ('project_root', ?)",
+            (str(self._project_root),),
+        )
+        self._conn.execute("COMMIT")
+
+    def _migrate_v1_to_v2(self) -> None:
+        """Add favorites and recently_viewed tables (v1 → v2)."""
+        self._conn.executescript("""
+            CREATE TABLE IF NOT EXISTS favorites (
+                rel_path TEXT PRIMARY KEY
+            );
+            CREATE TABLE IF NOT EXISTS recently_viewed (
+                rel_path  TEXT NOT NULL PRIMARY KEY,
+                viewed_at TEXT NOT NULL
+            );
+        """)
+        self._conn.execute("BEGIN")
+        self._conn.execute(
+            "INSERT OR REPLACE INTO meta (key, value) VALUES ('schema_version', '2')"
+        )
+        self._conn.execute("COMMIT")
 
     # ------------------------------------------------------------------
     # Public API — bulk operations
@@ -74,17 +131,21 @@ class IndexDB:
         """Full reindex: delete everything and insert all given queries."""
         with self._lock:
             self._conn.execute("BEGIN")
-            self._conn.execute("DELETE FROM query_objects")
-            self._conn.execute("DELETE FROM query_tags")
-            self._conn.execute("DELETE FROM queries")
-            self._conn.execute("DELETE FROM tags")
-            for query in queries:
-                self._insert_query(query)
-            self._conn.execute(
-                "INSERT OR REPLACE INTO meta (key, value) VALUES ('last_full_scan', ?)",
-                (datetime.now(timezone.utc).isoformat(),),
-            )
-            self._conn.execute("COMMIT")
+            try:
+                self._conn.execute("DELETE FROM query_objects")
+                self._conn.execute("DELETE FROM query_tags")
+                self._conn.execute("DELETE FROM queries")
+                self._conn.execute("DELETE FROM tags")
+                for query in queries:
+                    self._insert_query(query)
+                self._conn.execute(
+                    "INSERT OR REPLACE INTO meta (key, value) VALUES ('last_full_scan', ?)",
+                    (datetime.now(timezone.utc).isoformat(),),
+                )
+                self._conn.execute("COMMIT")
+            except Exception:
+                self._conn.execute("ROLLBACK")
+                raise
 
     def index_incremental(self, queries: list[Query]) -> int:
         """Smart reindex: skip files whose mtime+hash are unchanged.
@@ -229,6 +290,73 @@ class IndexDB:
             return _search(self._conn, text)
 
     # ------------------------------------------------------------------
+    # Public API — favorites
+    # ------------------------------------------------------------------
+
+    def toggle_favorite(self, rel_path: str) -> bool:
+        """Toggle favorite. Returns True if the query is now favorited."""
+        with self._lock:
+            exists = self._conn.execute(
+                "SELECT 1 FROM favorites WHERE rel_path=?", (rel_path,)
+            ).fetchone()
+            if exists:
+                self._conn.execute("DELETE FROM favorites WHERE rel_path=?", (rel_path,))
+                return False
+            else:
+                self._conn.execute(
+                    "INSERT INTO favorites (rel_path) VALUES (?)", (rel_path,)
+                )
+                return True
+
+    def is_favorite(self, rel_path: str) -> bool:
+        with self._lock:
+            return bool(
+                self._conn.execute(
+                    "SELECT 1 FROM favorites WHERE rel_path=?", (rel_path,)
+                ).fetchone()
+            )
+
+    def get_favorites(self) -> list[SearchResult]:
+        with self._lock:
+            rows = self._conn.execute(
+                "SELECT q.id, q.rel_path, q.title, COALESCE(q.description, ''), '', 0.0"
+                " FROM queries q"
+                " JOIN favorites f ON f.rel_path = q.rel_path"
+                " ORDER BY q.title"
+            ).fetchall()
+            return _rows_to_results_locked(self._conn, rows)
+
+    # ------------------------------------------------------------------
+    # Public API — recently viewed
+    # ------------------------------------------------------------------
+
+    def add_recently_viewed(self, rel_path: str) -> None:
+        now = datetime.now(timezone.utc).isoformat()
+        with self._lock:
+            self._conn.execute(
+                "INSERT OR REPLACE INTO recently_viewed (rel_path, viewed_at)"
+                " VALUES (?, ?)",
+                (rel_path, now),
+            )
+            self._conn.execute(
+                "DELETE FROM recently_viewed WHERE rel_path NOT IN ("
+                "  SELECT rel_path FROM recently_viewed ORDER BY viewed_at DESC LIMIT 20"
+                ")"
+            )
+
+    def get_recently_viewed(self, limit: int = 20) -> list[SearchResult]:
+        with self._lock:
+            rows = self._conn.execute(
+                "SELECT q.id, q.rel_path, q.title, COALESCE(q.description, ''), '', 0.0"
+                " FROM queries q"
+                " JOIN recently_viewed rv ON rv.rel_path = q.rel_path"
+                " ORDER BY rv.viewed_at DESC"
+                " LIMIT ?",
+                (limit,),
+            ).fetchall()
+            return _rows_to_results_locked(self._conn, rows)
+
+    # ------------------------------------------------------------------
     # Internal helpers (called while _lock is held)
     # ------------------------------------------------------------------
 
@@ -297,3 +425,12 @@ class IndexDB:
                 " VALUES (?, ?, ?, ?, ?)",
                 (query_id, query.title, query.description, query.body, objects_text),
             )
+
+
+def _rows_to_results_locked(
+    conn: sqlite3.Connection, rows: list[tuple]
+) -> list[SearchResult]:
+    """Build SearchResult list from raw rows (caller must hold the DB lock)."""
+    from .search import _rows_to_results
+
+    return _rows_to_results(conn, rows)

--- a/sqlshelf/core/schema.sql
+++ b/sqlshelf/core/schema.sql
@@ -64,3 +64,12 @@ CREATE TRIGGER queries_au AFTER UPDATE ON queries BEGIN
     INSERT INTO queries_fts(rowid, title, description, body, objects)
     VALUES (new.id, new.title, new.description, new.body, '');
 END;
+
+CREATE TABLE favorites (
+    rel_path TEXT PRIMARY KEY
+);
+
+CREATE TABLE recently_viewed (
+    rel_path  TEXT NOT NULL PRIMARY KEY,
+    viewed_at TEXT NOT NULL
+);

--- a/sqlshelf/core/snippets.py
+++ b/sqlshelf/core/snippets.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_TEMPLATES_DIR = Path.home() / ".sqlshelf" / "templates"
+
+# Matches {{param_name}} placeholders
+_PARAM_RE = re.compile(r"\{\{(\w+)\}\}")
+
+
+def get_templates_dir() -> Path:
+    """Return (and create if needed) the user-level templates folder."""
+    _TEMPLATES_DIR.mkdir(parents=True, exist_ok=True)
+    return _TEMPLATES_DIR
+
+
+def list_templates() -> list[Path]:
+    """Return all .sql template files sorted by name."""
+    d = get_templates_dir()
+    return sorted(d.glob("*.sql"), key=lambda p: p.stem.lower())
+
+
+def extract_params(template_body: str) -> list[str]:
+    """Return unique parameter names found in the template, preserving order."""
+    seen: set[str] = set()
+    params: list[str] = []
+    for m in _PARAM_RE.finditer(template_body):
+        name = m.group(1)
+        if name not in seen:
+            seen.add(name)
+            params.append(name)
+    return params
+
+
+def apply_template(template_body: str, params: dict[str, str]) -> str:
+    """Substitute {{param}} placeholders with the supplied values."""
+    def _replace(m: re.Match) -> str:  # type: ignore[type-arg]
+        return params.get(m.group(1), m.group(0))
+
+    return _PARAM_RE.sub(_replace, template_body)

--- a/sqlshelf/ui/command_palette.py
+++ b/sqlshelf/ui/command_palette.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from PySide6.QtCore import Qt, Signal
+from PySide6.QtGui import QKeyEvent
+from PySide6.QtWidgets import (
+    QDialog,
+    QLabel,
+    QLineEdit,
+    QListWidget,
+    QListWidgetItem,
+    QVBoxLayout,
+    QWidget,
+)
+
+from ..core.models import SearchResult
+
+
+class CommandPalette(QDialog):
+    """Ctrl+P floating quick-search overlay.
+
+    Shows all indexed queries; as the user types the list narrows.
+    Pressing Enter (or double-clicking) selects the highlighted query
+    and emits query_selected.
+
+    Usage::
+        palette = CommandPalette(results, parent)
+        palette.query_selected.connect(handler)
+        palette.exec()
+    """
+
+    query_selected = Signal(object)  # SearchResult
+
+    def __init__(self, results: list[SearchResult], parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("")
+        self.setWindowFlags(
+            Qt.WindowType.Dialog
+            | Qt.WindowType.FramelessWindowHint
+            | Qt.WindowType.NoDropShadowWindowHint
+        )
+        self.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground, False)
+        self.resize(560, 400)
+
+        self._all_results = results
+
+        hint = QLabel("Type to filter queries — Enter to open")
+        hint.setStyleSheet("color: #888888; font-size: 11px; padding: 2px 4px;")
+
+        self._search = QLineEdit()
+        self._search.setPlaceholderText("Search queries…")
+        self._search.textChanged.connect(self._filter)
+        self._search.installEventFilter(self)
+
+        self._list = QListWidget()
+        self._list.itemActivated.connect(self._on_activated)
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(8, 8, 8, 8)
+        layout.setSpacing(4)
+        layout.addWidget(hint)
+        layout.addWidget(self._search)
+        layout.addWidget(self._list)
+
+        self._populate(results)
+        if self._list.count() > 0:
+            self._list.setCurrentRow(0)
+
+    # ------------------------------------------------------------------
+
+    def _populate(self, results: list[SearchResult]) -> None:
+        self._list.clear()
+        for r in results:
+            item = QListWidgetItem(r.title)
+            item.setData(Qt.ItemDataRole.UserRole, r)
+            tags_str = "  ".join(f"#{t}" for t in r.tags)
+            item.setToolTip(f"{r.rel_path}\n{tags_str}" if tags_str else r.rel_path)
+            self._list.addItem(item)
+
+    def _filter(self, text: str) -> None:
+        text = text.strip().lower()
+        if not text:
+            self._populate(self._all_results)
+        else:
+            filtered = [
+                r for r in self._all_results
+                if text in r.title.lower()
+                or text in r.rel_path.lower()
+                or any(text in t.lower() for t in r.tags)
+            ]
+            self._populate(filtered)
+        if self._list.count() > 0:
+            self._list.setCurrentRow(0)
+
+    def _on_activated(self, item: QListWidgetItem) -> None:
+        result: SearchResult | None = item.data(Qt.ItemDataRole.UserRole)
+        if result is not None:
+            self.query_selected.emit(result)
+            self.accept()
+
+    # ------------------------------------------------------------------
+    # Keyboard navigation: Up/Down in search box moves list selection.
+    # ------------------------------------------------------------------
+
+    def eventFilter(self, obj, event) -> bool:
+        if obj is self._search and isinstance(event, QKeyEvent):
+            key = event.key()
+            if key == Qt.Key.Key_Down:
+                row = min(self._list.currentRow() + 1, self._list.count() - 1)
+                self._list.setCurrentRow(row)
+                return True
+            if key == Qt.Key.Key_Up:
+                row = max(self._list.currentRow() - 1, 0)
+                self._list.setCurrentRow(row)
+                return True
+            if key in (Qt.Key.Key_Return, Qt.Key.Key_Enter):
+                item = self._list.currentItem()
+                if item:
+                    self._on_activated(item)
+                return True
+            if key == Qt.Key.Key_Escape:
+                self.reject()
+                return True
+        return super().eventFilter(obj, event)

--- a/sqlshelf/ui/main_window.py
+++ b/sqlshelf/ui/main_window.py
@@ -5,10 +5,12 @@ import subprocess
 import sys
 from pathlib import Path
 
-from PySide6.QtCore import QObject, QRunnable, Qt, QThread, QThreadPool, Signal
-from PySide6.QtGui import QAction, QFont, QKeySequence
+from PySide6.QtCore import QObject, QRunnable, Qt, QThreadPool, Signal
+from PySide6.QtGui import QAction, QFont, QIcon, QKeySequence
 from PySide6.QtWidgets import (
+    QApplication,
     QFileDialog,
+    QInputDialog,
     QLabel,
     QMainWindow,
     QMenu,
@@ -18,6 +20,7 @@ from PySide6.QtWidgets import (
     QPushButton,
     QSplitter,
     QStatusBar,
+    QStyle,
     QToolBar,
     QVBoxLayout,
     QWidget,
@@ -28,13 +31,21 @@ from ..core.frontmatter import read_sql_file, write_sql_file
 from ..core.index_db import IndexDB
 from ..core.models import SearchResult
 from ..core.scanner import scan_folder
+from ..core.snippets import list_templates
 from ..core.watcher import FolderWatcher
+from .command_palette import CommandPalette
 from .highlighter import SqlHighlighter
 from .metadata_panel import MetadataPanel
 from .new_query_dialog import NewQueryDialog
 from .query_list import QueryListWidget
 from .search_bar import SearchBar
 from .sidebar import SidebarWidget
+from .template_dialog import TemplateDialog
+
+
+def _icon(style_enum) -> QIcon:
+    """Return a standard Qt style icon."""
+    return QApplication.style().standardIcon(style_enum)
 
 
 # ---------------------------------------------------------------------------
@@ -42,7 +53,8 @@ from .sidebar import SidebarWidget
 # ---------------------------------------------------------------------------
 
 class _IndexWorkerSignals(QObject):
-    finished = Signal(int)  # count indexed
+    finished = Signal(int)
+    error = Signal(str)
 
 
 class _IndexWorker(QRunnable):
@@ -53,9 +65,12 @@ class _IndexWorker(QRunnable):
         self._folder = folder
 
     def run(self) -> None:
-        queries = scan_folder(self._folder)
-        self._db.index_incremental(queries)
-        self.signals.finished.emit(self._db.count())
+        try:
+            queries = scan_folder(self._folder)
+            self._db.index_incremental(queries)
+            self.signals.finished.emit(self._db.count())
+        except Exception as exc:
+            self.signals.error.emit(str(exc))
 
 
 # ---------------------------------------------------------------------------
@@ -63,7 +78,7 @@ class _IndexWorker(QRunnable):
 # ---------------------------------------------------------------------------
 
 class _WatcherBridge(QObject):
-    files_changed = Signal(object, object)  # (set[Path], set[Path])
+    files_changed = Signal(object, object)
 
     def on_changed(self, modified: set[Path], deleted: set[Path]) -> None:
         self.files_changed.emit(modified, deleted)
@@ -85,7 +100,6 @@ class MainWindow(QMainWindow):
         self._watcher_bridge = _WatcherBridge()
         self._watcher_bridge.files_changed.connect(self._handle_files_changed)
 
-        # Current query state
         self._current_result: SearchResult | None = None
         self._current_metadata: dict = {}
         self._edit_mode = False
@@ -105,32 +119,54 @@ class MainWindow(QMainWindow):
         file_menu = QMenu("&File", self)
         mb.addMenu(file_menu)
 
-        open_act = QAction("Open Folder…", self)
+        open_act = QAction(
+            _icon(QStyle.StandardPixmap.SP_DirOpenIcon), "Open Folder…", self
+        )
         open_act.setShortcut(QKeySequence("Ctrl+O"))
         open_act.triggered.connect(self.open_folder)
         file_menu.addAction(open_act)
 
-        new_act = QAction("New Query…", self)
+        new_act = QAction(
+            _icon(QStyle.StandardPixmap.SP_FileIcon), "New Query…", self
+        )
         new_act.setShortcut(QKeySequence("Ctrl+N"))
         new_act.triggered.connect(self.new_query)
         file_menu.addAction(new_act)
 
+        self._new_template_act = QAction("New from Template…", self)
+        self._new_template_act.triggered.connect(self.new_from_template)
+        file_menu.addAction(self._new_template_act)
+
+        self._duplicate_act = QAction(
+            _icon(QStyle.StandardPixmap.SP_FileLinkIcon), "Duplicate Query…", self
+        )
+        self._duplicate_act.setShortcut(QKeySequence("Ctrl+D"))
+        self._duplicate_act.triggered.connect(self.duplicate_current)
+        file_menu.addAction(self._duplicate_act)
+
         file_menu.addSeparator()
 
         self._recent_menu = QMenu("Recent Projects", self)
+        self._recent_menu.setIcon(_icon(QStyle.StandardPixmap.SP_FileDialogStart))
         file_menu.addMenu(self._recent_menu)
         self._rebuild_recent_menu()
 
         file_menu.addSeparator()
 
-        reindex_act = QAction("Force Reindex", self)
+        reindex_act = QAction(
+            _icon(QStyle.StandardPixmap.SP_BrowserReload), "Force Reindex", self
+        )
         reindex_act.triggered.connect(self.force_reindex)
         file_menu.addAction(reindex_act)
 
         view_menu = QMenu("&View", self)
         mb.addMenu(view_menu)
 
-        reveal_act = QAction("Reveal File in Explorer", self)
+        reveal_act = QAction(
+            _icon(QStyle.StandardPixmap.SP_FileDialogDetailedView),
+            "Reveal File in Explorer",
+            self,
+        )
         reveal_act.triggered.connect(self.reveal_in_explorer)
         view_menu.addAction(reveal_act)
 
@@ -138,7 +174,11 @@ class MainWindow(QMainWindow):
         open_ssms_act.triggered.connect(self.open_in_ssms)
         view_menu.addAction(open_ssms_act)
 
-        copy_act = QAction("Copy SQL Body", self)
+        copy_act = QAction(
+            _icon(QStyle.StandardPixmap.SP_DialogSaveButton),
+            "Copy SQL (no frontmatter)",
+            self,
+        )
         copy_act.setShortcut(QKeySequence("Ctrl+Shift+C"))
         copy_act.triggered.connect(self.copy_sql)
         view_menu.addAction(copy_act)
@@ -148,6 +188,8 @@ class MainWindow(QMainWindow):
         self._sidebar = SidebarWidget()
         self._sidebar.open_folder_requested.connect(self.open_folder)
         self._sidebar.tag_selected.connect(self._on_tag_selected)
+        self._sidebar.favorites_selected.connect(self._on_favorites_selected)
+        self._sidebar.recent_selected.connect(self._on_recent_selected)
 
         # Middle panel
         middle = QWidget()
@@ -160,6 +202,7 @@ class MainWindow(QMainWindow):
 
         self._query_list = QueryListWidget()
         self._query_list.query_selected.connect(self._on_query_selected)
+        self._query_list.context_action.connect(self._on_list_context_action)
 
         mid_layout.addWidget(self._search_bar)
         mid_layout.addWidget(self._query_list)
@@ -171,27 +214,36 @@ class MainWindow(QMainWindow):
         right_layout.setSpacing(0)
 
         self._metadata_panel = MetadataPanel()
+        self._metadata_panel.table_clicked.connect(self._on_object_clicked)
 
         # Editor toolbar
         self._toolbar = QToolBar()
         self._toolbar.setMovable(False)
-        self._edit_toggle_btn = QPushButton("Edit")
+
+        self._edit_toggle_btn = QPushButton("✏  Edit")
         self._edit_toggle_btn.setCheckable(True)
         self._edit_toggle_btn.setToolTip("Toggle edit mode (Ctrl+E)")
         self._edit_toggle_btn.clicked.connect(self._toggle_edit_mode)
 
-        self._save_btn = QPushButton("Save")
+        self._save_btn = QPushButton("💾  Save")
         self._save_btn.setToolTip("Save changes (Ctrl+S)")
         self._save_btn.setEnabled(False)
         self._save_btn.clicked.connect(self.save_current)
 
-        self._cancel_btn = QPushButton("Cancel")
+        self._cancel_btn = QPushButton("✕  Cancel")
         self._cancel_btn.setEnabled(False)
         self._cancel_btn.clicked.connect(self._cancel_edit)
+
+        self._fav_btn = QPushButton("☆  Favorite")
+        self._fav_btn.setToolTip("Toggle favorite (click to star/unstar)")
+        self._fav_btn.setMinimumWidth(90)
+        self._fav_btn.clicked.connect(self._toggle_favorite)
 
         self._toolbar.addWidget(self._edit_toggle_btn)
         self._toolbar.addWidget(self._save_btn)
         self._toolbar.addWidget(self._cancel_btn)
+        self._toolbar.addSeparator()
+        self._toolbar.addWidget(self._fav_btn)
         self._toolbar.addSeparator()
         self._path_label = QLabel("")
         self._path_label.setStyleSheet("color: #888888; padding-left: 4px;")
@@ -230,6 +282,7 @@ class MainWindow(QMainWindow):
             lambda: self._edit_toggle_btn.click()
         )
         QShortcut(QKeySequence("Ctrl+N"), self).activated.connect(self.new_query)
+        QShortcut(QKeySequence("Ctrl+P"), self).activated.connect(self.open_command_palette)
 
     # ------------------------------------------------------------------
     # Folder / indexing
@@ -254,10 +307,13 @@ class MainWindow(QMainWindow):
 
         self.setWindowTitle(f"SQLShelf — {folder.name}")
         self._status_bar.showMessage("Indexing…")
-        self._cancel_edit_mode()
+        self._reset_editor()
 
         worker = _IndexWorker(self._db, folder)
         worker.signals.finished.connect(self._on_index_finished)
+        worker.signals.error.connect(
+            lambda msg: self._status_bar.showMessage(f"Index error: {msg}")
+        )
         QThreadPool.globalInstance().start(worker)
 
         self._watcher_bridge = _WatcherBridge()
@@ -273,10 +329,13 @@ class MainWindow(QMainWindow):
         if self._db is None or self._folder is None:
             return
         self._status_bar.showMessage("Full reindex…")
-        queries = scan_folder(self._folder)
-        self._db.index_all(queries)
-        self._status_bar.showMessage(f"{self._db.count()} queries indexed")
-        self._refresh_ui()
+        try:
+            queries = scan_folder(self._folder)
+            self._db.index_all(queries)
+            self._status_bar.showMessage(f"{self._db.count()} queries indexed")
+            self._refresh_ui()
+        except Exception as exc:
+            self._status_bar.showMessage(f"Reindex error: {exc}")
 
     def _stop_watcher(self) -> None:
         if self._watcher is not None:
@@ -293,6 +352,21 @@ class MainWindow(QMainWindow):
             action = QAction(str(path), self)
             action.triggered.connect(lambda checked, p=path: self.load_folder(p))
             self._recent_menu.addAction(action)
+
+    def _reset_editor(self) -> None:
+        """Clear editor and reset state without reloading from disk."""
+        self._edit_mode = False
+        self._editor.setReadOnly(True)
+        self._editor.clear()
+        self._metadata_panel.clear()
+        self._path_label.setText("")
+        self._fav_btn.setText("☆  Favorite")
+        self._save_btn.setEnabled(False)
+        self._cancel_btn.setEnabled(False)
+        self._edit_toggle_btn.setChecked(False)
+        self._edit_toggle_btn.setText("✏  Edit")
+        self._current_result = None
+        self._current_metadata = {}
 
     # ------------------------------------------------------------------
     # UI refresh
@@ -317,12 +391,27 @@ class MainWindow(QMainWindow):
     # ------------------------------------------------------------------
 
     def _on_query_selected(self, result: SearchResult) -> None:
-        self._cancel_edit_mode()
+        # Discard any unsaved edits without reloading (we're about to load new query)
+        if self._edit_mode:
+            self._edit_mode = False
+            self._editor.setReadOnly(True)
+            self._metadata_panel.set_edit_mode(False)
+            self._save_btn.setEnabled(False)
+            self._cancel_btn.setEnabled(False)
+            self._edit_toggle_btn.setChecked(False)
+            self._edit_toggle_btn.setText("✏  Edit")
+
         self._current_result = result
         if self._folder is None:
             return
         path = self._folder / result.rel_path
         self._load_query_from_disk(path, result)
+
+        if self._db is not None:
+            try:
+                self._db.add_recently_viewed(result.rel_path)
+            except Exception:
+                pass
 
     def _load_query_from_disk(self, path: Path, result: SearchResult) -> None:
         try:
@@ -337,8 +426,11 @@ class MainWindow(QMainWindow):
 
         objects: dict[str, list[str]] = {"table": [], "column": []}
         if self._db is not None:
-            obj_map = self._db.get_objects(result.query_id)
-            objects = obj_map
+            try:
+                obj_map = self._db.get_objects(result.query_id)
+                objects = obj_map
+            except Exception:
+                pass
 
         self._metadata_panel.set_query(
             title=result.title,
@@ -348,18 +440,130 @@ class MainWindow(QMainWindow):
             columns=objects.get("column", []),
         )
 
+        if self._db is not None:
+            try:
+                is_fav = self._db.is_favorite(result.rel_path)
+                self._fav_btn.setText("★  Favorite" if is_fav else "☆  Favorite")
+            except Exception:
+                self._fav_btn.setText("☆  Favorite")
+
     # ------------------------------------------------------------------
-    # Search / tag filtering
+    # Search / tag / sidebar filtering
     # ------------------------------------------------------------------
 
-    def _on_search_changed(self, text: str) -> None:
+    def _on_search_changed(self, _text: str) -> None:
+        self._sidebar.select_all()
         self._run_search()
 
     def _on_tag_selected(self, tag: str) -> None:
-        if tag:
-            self._search_bar._edit.setText(f"tag:{tag}")
-        else:
-            self._search_bar.clear()
+        self._search_bar.blockSignals(True)
+        self._search_bar._edit.setText(f"tag:{tag}" if tag else "")
+        self._search_bar.blockSignals(False)
+        self._run_search()
+
+    def _on_favorites_selected(self) -> None:
+        if self._db is None:
+            return
+        self._search_bar.blockSignals(True)
+        self._search_bar.clear()
+        self._search_bar.blockSignals(False)
+        try:
+            results = self._db.get_favorites()
+        except Exception:
+            results = []
+        self._query_list.set_results(results)
+
+    def _on_recent_selected(self) -> None:
+        if self._db is None:
+            return
+        self._search_bar.blockSignals(True)
+        self._search_bar.clear()
+        self._search_bar.blockSignals(False)
+        try:
+            results = self._db.get_recently_viewed()
+        except Exception:
+            results = []
+        self._query_list.set_results(results)
+
+    def _on_object_clicked(self, href: str) -> None:
+        """Reverse search: clicking a table/col name filters the query list."""
+        self._sidebar.select_all()
+        self._search_bar.blockSignals(True)
+        self._search_bar._edit.setText(href)
+        self._search_bar.blockSignals(False)
+        self._run_search()
+
+    # ------------------------------------------------------------------
+    # Context menu actions from QueryListWidget
+    # ------------------------------------------------------------------
+
+    def _on_list_context_action(self, action: str, result: SearchResult) -> None:
+        if action == "favorite":
+            self._query_list.select_by_rel_path(result.rel_path)
+            self._toggle_favorite_for(result)
+        elif action == "duplicate":
+            self._query_list.select_by_rel_path(result.rel_path)
+            self.duplicate_current()
+        elif action == "copy":
+            body = self._editor.toPlainText()
+            if self._current_result and self._current_result.rel_path != result.rel_path:
+                # Load body from disk for the right-clicked item
+                if self._folder:
+                    try:
+                        _, body, _ = read_sql_file(self._folder / result.rel_path)
+                    except Exception:
+                        pass
+            QApplication.clipboard().setText(body)
+            self._status_bar.showMessage(f"Copied: {result.rel_path}")
+        elif action == "reveal":
+            self._query_list.select_by_rel_path(result.rel_path)
+            self.reveal_in_explorer()
+
+    # ------------------------------------------------------------------
+    # Favorites
+    # ------------------------------------------------------------------
+
+    def _toggle_favorite(self) -> None:
+        if self._current_result is None:
+            return
+        self._toggle_favorite_for(self._current_result)
+
+    def _toggle_favorite_for(self, result: SearchResult) -> None:
+        if self._db is None:
+            return
+        try:
+            is_fav = self._db.toggle_favorite(result.rel_path)
+        except Exception:
+            return
+        label = "★  Favorite" if is_fav else "☆  Favorite"
+        if self._current_result and self._current_result.rel_path == result.rel_path:
+            self._fav_btn.setText(label)
+        self._status_bar.showMessage(
+            f"{'Added to' if is_fav else 'Removed from'} favorites: {result.rel_path}"
+        )
+
+    # ------------------------------------------------------------------
+    # Command palette (Ctrl+P)
+    # ------------------------------------------------------------------
+
+    def open_command_palette(self) -> None:
+        if self._db is None:
+            return
+        results = self._db.search("")
+        palette = CommandPalette(results, self)
+        palette.query_selected.connect(self._on_palette_selected)
+        geo = self.geometry()
+        pw, ph = palette.width(), palette.height()
+        palette.move(geo.center().x() - pw // 2, geo.center().y() - ph // 2)
+        palette.exec()
+
+    def _on_palette_selected(self, result: SearchResult) -> None:
+        self._sidebar.select_all()
+        self._search_bar.blockSignals(True)
+        self._search_bar.clear()
+        self._search_bar.blockSignals(False)
+        self._run_search()
+        self._query_list.select_by_rel_path(result.rel_path)
 
     # ------------------------------------------------------------------
     # Edit / Save
@@ -380,17 +584,18 @@ class MainWindow(QMainWindow):
         self._metadata_panel.set_edit_mode(True)
         self._save_btn.setEnabled(True)
         self._cancel_btn.setEnabled(True)
-        self._edit_toggle_btn.setText("Editing…")
+        self._edit_toggle_btn.setText("✏  Editing…")
 
     def _cancel_edit_mode(self) -> None:
+        """Exit edit mode, discarding unsaved changes by reloading from disk."""
         self._edit_mode = False
         self._editor.setReadOnly(True)
         self._metadata_panel.set_edit_mode(False)
         self._save_btn.setEnabled(False)
         self._cancel_btn.setEnabled(False)
         self._edit_toggle_btn.setChecked(False)
-        self._edit_toggle_btn.setText("Edit")
-        # Re-load from disk to discard unsaved changes
+        self._edit_toggle_btn.setText("✏  Edit")
+        # Reload from disk to discard unsaved changes
         if self._current_result is not None and self._folder is not None:
             path = self._folder / self._current_result.rel_path
             self._load_query_from_disk(path, self._current_result)
@@ -417,43 +622,117 @@ class MainWindow(QMainWindow):
             QMessageBox.critical(self, "Save Error", str(exc))
             return
 
-        # Reindex the saved file
         if self._db is not None:
-            from ..core.scanner import scan_folder as _scan
-
-            updated = [q for q in _scan(self._folder) if q.path == path]
+            updated = [q for q in scan_folder(self._folder) if q.path == path]
             if updated:
                 self._db.upsert_query(updated[0])
 
-        self._cancel_edit_mode()
+        self._edit_mode = False
+        self._editor.setReadOnly(True)
+        self._metadata_panel.set_edit_mode(False)
+        self._save_btn.setEnabled(False)
+        self._cancel_btn.setEnabled(False)
+        self._edit_toggle_btn.setChecked(False)
+        self._edit_toggle_btn.setText("✏  Edit")
         self._refresh_ui()
         self._status_bar.showMessage(f"Saved: {self._current_result.rel_path}")
 
     # ------------------------------------------------------------------
-    # New query
+    # New query / duplicate / templates
     # ------------------------------------------------------------------
 
     def new_query(self) -> None:
         if self._folder is None:
             QMessageBox.information(self, "No Folder", "Open a folder first.")
             return
+        subfolders = self._list_subfolders()
+        dlg = NewQueryDialog(self._folder, subfolders, self)
+        if dlg.exec() == dlg.DialogCode.Accepted and dlg.created_path is not None:
+            self._post_create(dlg.created_path)
 
-        subfolders = [
+    def new_from_template(self) -> None:
+        if self._folder is None:
+            QMessageBox.information(self, "No Folder", "Open a folder first.")
+            return
+        if not list_templates():
+            QMessageBox.information(
+                self,
+                "No Templates",
+                f"No templates found.\n\nCreate .sql files in:\n"
+                f"{Path.home() / '.sqlshelf' / 'templates'}",
+            )
+            return
+        dlg = TemplateDialog(self._folder, self._list_subfolders(), self)
+        if dlg.exec() == dlg.DialogCode.Accepted and dlg.created_path is not None:
+            self._post_create(dlg.created_path)
+
+    def duplicate_current(self) -> None:
+        if self._current_result is None or self._folder is None:
+            QMessageBox.information(self, "No Query", "Select a query to duplicate.")
+            return
+
+        src_path = self._folder / self._current_result.rel_path
+        new_title, ok = QInputDialog.getText(
+            self,
+            "Duplicate Query",
+            "New query title:",
+            text=f"Copy of {self._current_result.title}",
+        )
+        if not ok or not new_title.strip():
+            return
+
+        new_title = new_title.strip()
+        try:
+            metadata, body, _has_fm = read_sql_file(src_path)
+        except Exception as exc:
+            QMessageBox.critical(self, "Duplicate Error", str(exc))
+            return
+
+        from .new_query_dialog import _safe_filename
+
+        filename = _safe_filename(new_title) + ".sql"
+        dest_path = src_path.parent / filename
+        counter = 1
+        while dest_path.exists():
+            dest_path = src_path.parent / f"{_safe_filename(new_title)}_{counter}.sql"
+            counter += 1
+
+        from datetime import date
+
+        new_meta = dict(metadata)
+        new_meta["title"] = new_title
+        today = date.today().isoformat()
+        new_meta["created"] = today
+        new_meta["updated"] = today
+
+        try:
+            write_sql_file(dest_path, new_meta, body)
+        except Exception as exc:
+            QMessageBox.critical(self, "Duplicate Error", str(exc))
+            return
+
+        self._post_create(dest_path)
+
+    def _list_subfolders(self) -> list[str]:
+        if self._folder is None:
+            return []
+        return [
             str(p.relative_to(self._folder))
             for p in self._folder.rglob("*")
             if p.is_dir() and ".sqlshelf" not in p.parts
         ]
 
-        dlg = NewQueryDialog(self._folder, subfolders, self)
-        if dlg.exec() == dlg.DialogCode.Accepted and dlg.created_path is not None:
-            path = dlg.created_path
-            from ..core.scanner import scan_folder as _scan
-
-            updated = [q for q in _scan(self._folder) if q.path == path]
-            if updated and self._db is not None:
-                self._db.upsert_query(updated[0])
-            self._refresh_ui()
-            self._status_bar.showMessage(f"Created: {path.name}")
+    def _post_create(self, path: Path) -> None:
+        if self._folder is None:
+            return
+        updated = [q for q in scan_folder(self._folder) if q.path == path]
+        if updated and self._db is not None:
+            self._db.upsert_query(updated[0])
+        self._refresh_ui()
+        self._query_list.select_by_rel_path(
+            path.relative_to(self._folder).as_posix()
+        )
+        self._status_bar.showMessage(f"Created: {path.name}")
 
     # ------------------------------------------------------------------
     # Watcher handler
@@ -462,24 +741,19 @@ class MainWindow(QMainWindow):
     def _handle_files_changed(self, modified: set[Path], deleted: set[Path]) -> None:
         if self._db is None or self._folder is None:
             return
-
-        from ..core.scanner import scan_folder as _scan
-
         for path in modified:
             if path.is_file():
                 try:
-                    hits = [q for q in _scan(self._folder) if q.path == path]
+                    hits = [q for q in scan_folder(self._folder) if q.path == path]
                     if hits:
                         self._db.upsert_query(hits[0])
                 except Exception:
                     pass
-
         for path in deleted:
             try:
                 self._db.remove_file(path)
             except Exception:
                 pass
-
         self._refresh_ui()
         self._status_bar.showMessage(f"{self._db.count()} queries indexed")
 
@@ -511,8 +785,6 @@ class MainWindow(QMainWindow):
             QMessageBox.information(self, "Open in SSMS", "Only available on Windows.")
 
     def copy_sql(self) -> None:
-        from PySide6.QtWidgets import QApplication
-
         body = self._editor.toPlainText()
         if body:
             QApplication.clipboard().setText(body)

--- a/sqlshelf/ui/metadata_panel.py
+++ b/sqlshelf/ui/metadata_panel.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from PySide6.QtCore import Signal
+from PySide6.QtCore import Qt, Signal
 from PySide6.QtWidgets import (
     QFormLayout,
     QLabel,
@@ -16,9 +16,14 @@ class MetadataPanel(QWidget):
     """Right-panel top section: title, description, tags, SQL objects.
 
     In read-only mode shows labels; edit mode makes title/description/tags editable.
+
+    Signals:
+        metadata_changed(title, description, tags)
+        table_clicked(str)  — user clicked a table name → trigger reverse search.
     """
 
-    metadata_changed = Signal(str, str, list)  # title, description, tags
+    metadata_changed = Signal(str, str, list)
+    table_clicked = Signal(str)
 
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
@@ -40,6 +45,9 @@ class MetadataPanel(QWidget):
         self._objects_label = QLabel()
         self._objects_label.setWordWrap(True)
         self._objects_label.setStyleSheet("color: #88aa88; font-size: 11px;")
+        self._objects_label.setTextFormat(Qt.TextFormat.RichText)
+        self._objects_label.setOpenExternalLinks(False)
+        self._objects_label.linkActivated.connect(self._on_object_link)
 
         # --- edit-mode widgets ---
         self._title_edit = QLineEdit()
@@ -96,11 +104,19 @@ class MetadataPanel(QWidget):
         self._desc_label.setText(description)
         self._tags_label.setText("  ".join(f"#{t}" for t in tags))
 
-        parts = []
+        parts: list[str] = []
         if tables:
-            parts.append("Tables: " + ", ".join(sorted(tables)))
+            links = " ".join(
+                f'<a href="table:{t}" style="color:#88aa88;">{t}</a>'
+                for t in sorted(tables)
+            )
+            parts.append(f"Tables: {links}")
         if columns:
-            parts.append("Columns: " + ", ".join(sorted(columns)))
+            col_links = " ".join(
+                f'<a href="col:{c}" style="color:#88aa88;">{c}</a>'
+                for c in sorted(columns)
+            )
+            parts.append(f"Columns: {col_links}")
         self._objects_label.setText("  |  ".join(parts) if parts else "")
 
         self._title_edit.setText(title)
@@ -130,3 +146,14 @@ class MetadataPanel(QWidget):
         self._title_edit.clear()
         self._desc_edit.clear()
         self._tags_edit.clear()
+
+    # ------------------------------------------------------------------
+    # Internal
+    # ------------------------------------------------------------------
+
+    def _on_object_link(self, href: str) -> None:
+        """Translate link hrefs to search-bar prefixes."""
+        if href.startswith("table:"):
+            self.table_clicked.emit(href)
+        elif href.startswith("col:"):
+            self.table_clicked.emit(href)

--- a/sqlshelf/ui/query_list.py
+++ b/sqlshelf/ui/query_list.py
@@ -1,7 +1,13 @@
 from __future__ import annotations
 
-from PySide6.QtCore import Signal
-from PySide6.QtWidgets import QListWidget, QListWidgetItem, QVBoxLayout, QWidget
+from PySide6.QtCore import Qt, Signal
+from PySide6.QtWidgets import (
+    QListWidget,
+    QListWidgetItem,
+    QMenu,
+    QVBoxLayout,
+    QWidget,
+)
 
 from ..core.models import SearchResult
 
@@ -9,13 +15,17 @@ from ..core.models import SearchResult
 class QueryListWidget(QWidget):
     """Middle panel: displays search results and emits query_selected."""
 
-    query_selected = Signal(object)  # SearchResult
+    query_selected = Signal(object)   # SearchResult
+    context_action = Signal(str, object)  # (action_name, SearchResult)
 
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
         self._list = QListWidget()
         self._results: list[SearchResult] = []
         self._list.currentRowChanged.connect(self._on_row_changed)
+
+        self._list.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
+        self._list.customContextMenuRequested.connect(self._show_context_menu)
 
         layout = QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
@@ -41,6 +51,13 @@ class QueryListWidget(QWidget):
         elif results:
             self._list.setCurrentRow(0)
 
+    def select_by_rel_path(self, rel_path: str) -> None:
+        """Select the item matching rel_path, if present."""
+        for i, r in enumerate(self._results):
+            if r.rel_path == rel_path:
+                self._list.setCurrentRow(i)
+                return
+
     def _current_rel_path(self) -> str | None:
         row = self._list.currentRow()
         if 0 <= row < len(self._results):
@@ -50,6 +67,36 @@ class QueryListWidget(QWidget):
     def _on_row_changed(self, row: int) -> None:
         if 0 <= row < len(self._results):
             self.query_selected.emit(self._results[row])
+
+    def _show_context_menu(self, pos) -> None:
+        row = self._list.currentRow()
+        item = self._list.itemAt(pos)
+        if item is None:
+            return
+        # Resolve which result was right-clicked (may differ from currentRow)
+        clicked_row = self._list.row(item)
+        if 0 <= clicked_row < len(self._results):
+            result = self._results[clicked_row]
+        else:
+            return
+
+        menu = QMenu(self._list)
+
+        fav_act = menu.addAction("☆  Toggle Favorite")
+        dup_act = menu.addAction("⎘  Duplicate Query…")
+        copy_act = menu.addAction("📋  Copy SQL")
+        menu.addSeparator()
+        reveal_act = menu.addAction("📂  Reveal in Explorer")
+
+        chosen = menu.exec(self._list.mapToGlobal(pos))
+        if chosen is fav_act:
+            self.context_action.emit("favorite", result)
+        elif chosen is dup_act:
+            self.context_action.emit("duplicate", result)
+        elif chosen is copy_act:
+            self.context_action.emit("copy", result)
+        elif chosen is reveal_act:
+            self.context_action.emit("reveal", result)
 
     def count(self) -> int:
         return len(self._results)

--- a/sqlshelf/ui/sidebar.py
+++ b/sqlshelf/ui/sidebar.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from PySide6.QtCore import Signal
+from PySide6.QtCore import Qt, Signal
 from PySide6.QtWidgets import (
+    QAbstractItemView,
     QLabel,
     QListWidget,
     QListWidgetItem,
@@ -10,17 +11,25 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
+_ALL_ITEM_TEXT = "All queries"
+_FAVORITES_ITEM_TEXT = "★  Favorites"
+_RECENT_ITEM_TEXT = "⌛  Recent"
+
 
 class SidebarWidget(QWidget):
-    """Left panel: Open Folder button and tag browser.
+    """Left panel: Open Folder button, Favorites/Recent shortcuts, and tag browser.
 
-    Emits:
-        open_folder_requested — user clicked Open Folder.
-        tag_selected(str)     — user clicked a tag; empty string = all.
+    Signals:
+        open_folder_requested  — user clicked Open Folder.
+        tag_selected(str)      — user clicked a tag; empty string = all queries.
+        favorites_selected     — user clicked Favorites.
+        recent_selected        — user clicked Recent.
     """
 
     open_folder_requested = Signal()
     tag_selected = Signal(str)
+    favorites_selected = Signal()
+    recent_selected = Signal()
 
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
@@ -29,53 +38,96 @@ class SidebarWidget(QWidget):
         app_title = QLabel("SQLSHELF")
         app_title.setStyleSheet("font-weight: bold; font-size: 14px; letter-spacing: 1px;")
 
-        self._open_btn = QPushButton("Open Folder…")
+        self._open_btn = QPushButton("📂  Open Folder…")
         self._open_btn.clicked.connect(self.open_folder_requested)
 
-        tags_label = QLabel("TAGS")
-        tags_label.setStyleSheet("font-weight: bold; margin-top: 12px; color: #aaaaaa;")
+        nav_label = QLabel("BROWSE")
+        nav_label.setStyleSheet("font-weight: bold; margin-top: 12px; color: #aaaaaa;")
 
-        self._all_item = QListWidgetItem("All queries")
+        self._nav_list = QListWidget()
+        self._nav_list.setSelectionMode(QAbstractItemView.SelectionMode.SingleSelection)
+        # Disable scrollbars — the 3 nav items must always be fully visible
+        self._nav_list.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        self._nav_list.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+
+        self._all_item = QListWidgetItem(_ALL_ITEM_TEXT)
+        self._fav_item = QListWidgetItem(_FAVORITES_ITEM_TEXT)
+        self._recent_item = QListWidgetItem(_RECENT_ITEM_TEXT)
+        self._nav_list.addItem(self._all_item)
+        self._nav_list.addItem(self._fav_item)
+        self._nav_list.addItem(self._recent_item)
+        self._nav_list.setCurrentItem(self._all_item)
+
+        # Use itemClicked so re-clicking the already-selected item also fires
+        self._nav_list.itemClicked.connect(self._on_nav_item_clicked)
+
+        tags_label = QLabel("TAGS")
+        tags_label.setStyleSheet("font-weight: bold; margin-top: 8px; color: #aaaaaa;")
+
         self._tag_list = QListWidget()
-        self._tag_list.addItem(self._all_item)
-        self._tag_list.setCurrentItem(self._all_item)
-        self._tag_list.currentItemChanged.connect(self._on_tag_changed)
+        self._tag_list.itemClicked.connect(self._on_tag_item_clicked)
 
         layout = QVBoxLayout(self)
         layout.setContentsMargins(8, 8, 8, 8)
         layout.addWidget(app_title)
         layout.addWidget(self._open_btn)
+        layout.addWidget(nav_label)
+        layout.addWidget(self._nav_list)
         layout.addWidget(tags_label)
-        layout.addWidget(self._tag_list)
+        layout.addWidget(self._tag_list, stretch=1)
+
+        self._update_nav_height()
+
+    def _update_nav_height(self) -> None:
+        """Size the nav list to exactly fit its 3 items with no scrollbar."""
+        self._nav_list.adjustSize()
+        total = sum(
+            self._nav_list.sizeHintForRow(i) for i in range(self._nav_list.count())
+        )
+        self._nav_list.setFixedHeight(total + 6)
 
     def set_tags(self, tags: list[str]) -> None:
         """Refresh the tag list. Preserves current selection if still valid."""
         current = self._selected_tag()
         self._tag_list.blockSignals(True)
         self._tag_list.clear()
-        self._all_item = QListWidgetItem("All queries")
-        self._tag_list.addItem(self._all_item)
         for tag in sorted(tags):
             self._tag_list.addItem(QListWidgetItem(tag))
         self._tag_list.blockSignals(False)
-        # Restore selection
         if current:
             for i in range(self._tag_list.count()):
                 if self._tag_list.item(i).text() == current:
                     self._tag_list.setCurrentRow(i)
                     return
-        self._tag_list.setCurrentRow(0)
+        self._tag_list.clearSelection()
+
+    def select_all(self) -> None:
+        """Programmatically switch the nav selection back to 'All queries'."""
+        self._nav_list.blockSignals(True)
+        self._nav_list.setCurrentItem(self._all_item)
+        self._nav_list.blockSignals(False)
+        self._tag_list.clearSelection()
 
     def _selected_tag(self) -> str:
         item = self._tag_list.currentItem()
-        if item is None or item is self._all_item or item.text() == "All queries":
-            return ""
-        return item.text()
+        return item.text() if item else ""
 
-    def _on_tag_changed(self, current: QListWidgetItem | None, _prev) -> None:
-        if current is None:
-            self.tag_selected.emit("")
-        elif current is self._all_item or current.text() == "All queries":
-            self.tag_selected.emit("")
+    def _on_nav_item_clicked(self, item: QListWidgetItem) -> None:
+        # Deselect tag list when a nav item is clicked
+        self._tag_list.blockSignals(True)
+        self._tag_list.clearSelection()
+        self._tag_list.blockSignals(False)
+        text = item.text()
+        if text == _FAVORITES_ITEM_TEXT:
+            self.favorites_selected.emit()
+        elif text == _RECENT_ITEM_TEXT:
+            self.recent_selected.emit()
         else:
-            self.tag_selected.emit(current.text())
+            self.tag_selected.emit("")
+
+    def _on_tag_item_clicked(self, item: QListWidgetItem) -> None:
+        # Switch nav to "All" silently when a tag is clicked
+        self._nav_list.blockSignals(True)
+        self._nav_list.setCurrentItem(self._all_item)
+        self._nav_list.blockSignals(False)
+        self.tag_selected.emit(item.text())

--- a/sqlshelf/ui/template_dialog.py
+++ b/sqlshelf/ui/template_dialog.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from PySide6.QtWidgets import (
+    QComboBox,
+    QDialog,
+    QDialogButtonBox,
+    QFormLayout,
+    QLabel,
+    QLineEdit,
+    QMessageBox,
+    QPlainTextEdit,
+    QVBoxLayout,
+    QWidget,
+)
+
+from ..core.frontmatter import write_sql_file
+from ..core.snippets import apply_template, extract_params, list_templates
+
+
+def _safe_filename(title: str) -> str:
+    name = title.strip().lower()
+    name = re.sub(r"[^\w\s-]", "", name)
+    name = re.sub(r"[\s_]+", "_", name)
+    return name or "query"
+
+
+class TemplateDialog(QDialog):
+    """Picker for parametrizable SQL templates.
+
+    Templates live in ~/.sqlshelf/templates/*.sql.
+    Placeholders use {{param_name}} syntax.
+
+    After accept(), ``created_path`` holds the new .sql file path.
+    """
+
+    def __init__(
+        self,
+        project_root: Path,
+        subfolders: list[str],
+        parent: QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("New from Template")
+        self.resize(640, 520)
+        self._project_root = project_root
+        self.created_path: Path | None = None
+
+        templates = list_templates()
+        if not templates:
+            # Nothing to show — caller should guard against this
+            pass
+
+        self._templates = templates
+        self._params_widgets: dict[str, QLineEdit] = {}
+
+        self._template_combo = QComboBox()
+        for t in templates:
+            self._template_combo.addItem(t.stem, userData=t)
+        self._template_combo.currentIndexChanged.connect(self._on_template_changed)
+
+        self._title_edit = QLineEdit()
+        self._title_edit.setPlaceholderText("New query title")
+
+        self._tags_edit = QLineEdit()
+        self._tags_edit.setPlaceholderText("Tags (comma-separated)")
+
+        self._folder_combo = QComboBox()
+        self._folder_combo.addItem("(project root)")
+        for sf in sorted(subfolders):
+            self._folder_combo.addItem(sf)
+
+        self._params_form = QFormLayout()
+
+        self._preview = QPlainTextEdit()
+        self._preview.setReadOnly(True)
+        self._preview.setPlaceholderText("Template preview…")
+        self._preview.setMaximumHeight(140)
+
+        buttons = QDialogButtonBox(
+            QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
+        )
+        buttons.accepted.connect(self._on_accept)
+        buttons.rejected.connect(self.reject)
+
+        layout = QVBoxLayout(self)
+        layout.addWidget(QLabel("Template:"))
+        layout.addWidget(self._template_combo)
+        layout.addWidget(QLabel("Query title:"))
+        layout.addWidget(self._title_edit)
+
+        form = QFormLayout()
+        form.addRow("Tags:", self._tags_edit)
+        form.addRow("Folder:", self._folder_combo)
+        layout.addLayout(form)
+
+        layout.addWidget(QLabel("Template parameters:"))
+        layout.addLayout(self._params_form)
+        layout.addWidget(QLabel("Preview:"))
+        layout.addWidget(self._preview)
+        layout.addWidget(buttons)
+
+        if templates:
+            self._on_template_changed(0)
+
+    def _current_template_body(self) -> str:
+        idx = self._template_combo.currentIndex()
+        if idx < 0 or idx >= len(self._templates):
+            return ""
+        path: Path = self._template_combo.itemData(idx)
+        try:
+            return path.read_text(encoding="utf-8")
+        except OSError:
+            return ""
+
+    def _on_template_changed(self, _idx: int) -> None:
+        body = self._current_template_body()
+        params = extract_params(body)
+
+        # Rebuild params form
+        while self._params_form.rowCount():
+            self._params_form.removeRow(0)
+        self._params_widgets.clear()
+
+        for param in params:
+            edit = QLineEdit()
+            edit.setPlaceholderText(param)
+            edit.textChanged.connect(self._update_preview)
+            self._params_widgets[param] = edit
+            self._params_form.addRow(f"{param}:", edit)
+
+        self._update_preview()
+
+    def _update_preview(self) -> None:
+        body = self._current_template_body()
+        vals = {k: w.text() for k, w in self._params_widgets.items()}
+        self._preview.setPlainText(apply_template(body, vals))
+
+    def _on_accept(self) -> None:
+        title = self._title_edit.text().strip()
+        if not title:
+            QMessageBox.warning(self, "Validation", "Title is required.")
+            return
+
+        body = self._current_template_body()
+        if not body:
+            QMessageBox.warning(self, "Validation", "No template selected or template is empty.")
+            return
+
+        params = {k: w.text() for k, w in self._params_widgets.items()}
+        filled_body = apply_template(body, params)
+
+        folder_text = self._folder_combo.currentText()
+        if folder_text == "(project root)":
+            target_dir = self._project_root
+        else:
+            target_dir = self._project_root / folder_text
+            target_dir.mkdir(parents=True, exist_ok=True)
+
+        filename = _safe_filename(title) + ".sql"
+        path = target_dir / filename
+        counter = 1
+        while path.exists():
+            path = target_dir / f"{_safe_filename(title)}_{counter}.sql"
+            counter += 1
+
+        raw_tags = self._tags_edit.text()
+        tags = [t.strip().lower() for t in raw_tags.split(",") if t.strip()]
+        metadata: dict = {"title": title, "tags": tags}
+
+        write_sql_file(path, metadata, filled_body)
+        self.created_path = path
+        self.accept()

--- a/tests/test_index_db.py
+++ b/tests/test_index_db.py
@@ -309,3 +309,198 @@ class TestScannerIntegration:
         db.close()
         assert row[0] == "plain"
         assert row[1] == 0
+
+
+# ---------------------------------------------------------------------------
+# Schema v2 tables
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaV2:
+    def test_favorites_table_exists(self, project_dir: Path) -> None:
+        db = IndexDB(project_dir)
+        row = db._conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='favorites'"
+        ).fetchone()
+        db.close()
+        assert row is not None
+
+    def test_recently_viewed_table_exists(self, project_dir: Path) -> None:
+        db = IndexDB(project_dir)
+        row = db._conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='recently_viewed'"
+        ).fetchone()
+        db.close()
+        assert row is not None
+
+    def test_schema_version_is_2(self, project_dir: Path) -> None:
+        db = IndexDB(project_dir)
+        row = db._conn.execute(
+            "SELECT value FROM meta WHERE key='schema_version'"
+        ).fetchone()
+        db.close()
+        assert row is not None and row[0] == "2"
+
+    def test_migration_v1_to_v2(self, project_dir: Path) -> None:
+        """Simulate a v1 DB and verify migration adds the new tables."""
+        import re
+        import sqlite3
+        from importlib.resources import files
+
+        db_path = project_dir / ".sqlshelf" / "index.db"
+        (project_dir / ".sqlshelf").mkdir(parents=True, exist_ok=True)
+        schema_sql = (
+            files("sqlshelf.core").joinpath("schema.sql").read_text(encoding="utf-8")
+        )
+        # Strip the v2 CREATE TABLE blocks to produce a v1-equivalent schema
+        v1_schema = re.sub(
+            r"CREATE TABLE (favorites|recently_viewed)\s*\([^)]*\);",
+            "",
+            schema_sql,
+            flags=re.DOTALL,
+        ).strip()
+
+        conn = sqlite3.connect(str(db_path))
+        conn.executescript(v1_schema)
+        conn.execute("BEGIN")
+        conn.execute("INSERT INTO meta (key, value) VALUES ('schema_version', '1')")
+        conn.execute(
+            "INSERT INTO meta (key, value) VALUES ('project_root', ?)",
+            (str(project_dir),),
+        )
+        conn.execute("COMMIT")
+        conn.close()
+
+        # Now open with IndexDB — should run migration
+        db = IndexDB(project_dir)
+        row = db._conn.execute(
+            "SELECT value FROM meta WHERE key='schema_version'"
+        ).fetchone()
+        fav_table = db._conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='favorites'"
+        ).fetchone()
+        rv_table = db._conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='recently_viewed'"
+        ).fetchone()
+        db.close()
+        assert row[0] == "2"
+        assert fav_table is not None
+        assert rv_table is not None
+
+
+# ---------------------------------------------------------------------------
+# Favorites
+# ---------------------------------------------------------------------------
+
+
+class TestFavorites:
+    def _indexed_db(self, project_dir: Path) -> tuple[IndexDB, str]:
+        p = make_sql_file(project_dir, "q.sql", "SELECT 1")
+        db = IndexDB(project_dir)
+        db.index_all([Query(path=p, title="Q", body="SELECT 1")])
+        return db, "q.sql"
+
+    def test_toggle_adds_favorite(self, project_dir: Path) -> None:
+        db, rel = self._indexed_db(project_dir)
+        result = db.toggle_favorite(rel)
+        db.close()
+        assert result is True
+
+    def test_toggle_removes_favorite(self, project_dir: Path) -> None:
+        db, rel = self._indexed_db(project_dir)
+        db.toggle_favorite(rel)
+        result = db.toggle_favorite(rel)
+        db.close()
+        assert result is False
+
+    def test_is_favorite_false_by_default(self, project_dir: Path) -> None:
+        db, rel = self._indexed_db(project_dir)
+        assert db.is_favorite(rel) is False
+        db.close()
+
+    def test_is_favorite_true_after_toggle(self, project_dir: Path) -> None:
+        db, rel = self._indexed_db(project_dir)
+        db.toggle_favorite(rel)
+        assert db.is_favorite(rel) is True
+        db.close()
+
+    def test_get_favorites_returns_results(self, project_dir: Path) -> None:
+        db, rel = self._indexed_db(project_dir)
+        db.toggle_favorite(rel)
+        results = db.get_favorites()
+        db.close()
+        assert len(results) == 1
+        assert results[0].rel_path == rel
+
+    def test_get_favorites_empty_when_none(self, project_dir: Path) -> None:
+        db, _ = self._indexed_db(project_dir)
+        assert db.get_favorites() == []
+        db.close()
+
+    def test_unfavorited_query_not_in_get_favorites(self, project_dir: Path) -> None:
+        db, rel = self._indexed_db(project_dir)
+        db.toggle_favorite(rel)
+        db.toggle_favorite(rel)
+        assert db.get_favorites() == []
+        db.close()
+
+
+# ---------------------------------------------------------------------------
+# Recently viewed
+# ---------------------------------------------------------------------------
+
+
+class TestRecentlyViewed:
+    def _indexed_db(self, project_dir: Path, n: int = 1) -> tuple[IndexDB, list[str]]:
+        rels = []
+        queries = []
+        for i in range(n):
+            p = make_sql_file(project_dir, f"q{i}.sql", f"SELECT {i}")
+            queries.append(Query(path=p, title=f"Q{i}", body=f"SELECT {i}"))
+            rels.append(f"q{i}.sql")
+        db = IndexDB(project_dir)
+        db.index_all(queries)
+        return db, rels
+
+    def test_add_recently_viewed_persisted(self, project_dir: Path) -> None:
+        db, rels = self._indexed_db(project_dir)
+        db.add_recently_viewed(rels[0])
+        results = db.get_recently_viewed()
+        db.close()
+        assert len(results) == 1
+        assert results[0].rel_path == rels[0]
+
+    def test_most_recent_first(self, project_dir: Path) -> None:
+        db, rels = self._indexed_db(project_dir, n=3)
+        for rel in rels:
+            db.add_recently_viewed(rel)
+        results = db.get_recently_viewed()
+        db.close()
+        # Last added should be first
+        assert results[0].rel_path == rels[-1]
+
+    def test_duplicate_view_moves_to_top(self, project_dir: Path) -> None:
+        db, rels = self._indexed_db(project_dir, n=2)
+        db.add_recently_viewed(rels[0])
+        db.add_recently_viewed(rels[1])
+        db.add_recently_viewed(rels[0])  # re-view the first one
+        results = db.get_recently_viewed()
+        db.close()
+        assert results[0].rel_path == rels[0]
+
+    def test_limit_respected(self, project_dir: Path) -> None:
+        db, rels = self._indexed_db(project_dir, n=3)
+        for rel in rels:
+            db.add_recently_viewed(rel)
+        results = db.get_recently_viewed(limit=2)
+        db.close()
+        assert len(results) == 2
+
+    def test_deleted_query_not_in_recent(self, project_dir: Path) -> None:
+        db, rels = self._indexed_db(project_dir, n=2)
+        for rel in rels:
+            db.add_recently_viewed(rel)
+        db.remove_file(project_dir / rels[0])
+        results = db.get_recently_viewed()
+        db.close()
+        assert all(r.rel_path != rels[0] for r in results)


### PR DESCRIPTION
- Favorites: toggle (★/☆ button + right-click menu), sidebar section, IndexDB.toggle_favorite / is_favorite / get_favorites
- Recently viewed: auto-tracked on query open, sidebar "⌛ Recent" section, IndexDB.add_recently_viewed / get_recently_viewed
- Duplicate query: Ctrl+D / File menu, copies file with updated frontmatter
- Snippets/templates: ~/.sqlshelf/templates/*.sql with {{param}} substitution; TemplateDialog with live preview and parameter forms
- Command palette: Ctrl+P frameless overlay, fuzzy filter, keyboard nav
- Reverse search: table/column names in MetadataPanel rendered as clickable HTML links → populates search bar with table:/col: prefix
- Right-click context menu on query list: Favorite, Duplicate, Copy SQL, Reveal in Explorer
- Icons added to menus (QStyle.StandardPixmap) and toolbar (unicode symbols)
- Schema v2 migration: adds favorites + recently_viewed tables; robust compatibility check — incompatible/partial DBs are wiped and rebuilt cleanly
- ROLLBACK added to index_all on exception; indexing errors surface via signal
- Sidebar Browse: scrollbar removed, itemClicked used so re-clicking fires
- PyInstaller packaging: sqlshelf.spec, build_app.ps1
- GitHub Actions CI: test on ubuntu+windows, build artefact, attach to release
- 16 new tests (104 total passing): schema v2, migration, favorites, recent