### PR TITLE
fix: UI polish — menu colors, selection, alignment, shortcuts

### DIFF
--- a/sqlshelf/ui/main_window.py
+++ b/sqlshelf/ui/main_window.py
@@ -180,6 +180,17 @@ class MainWindow(QMainWindow):
         view_menu = QMenu("&View", self)
         mb.addMenu(view_menu)
 
+        help_menu = QMenu("&Help", self)
+        mb.addMenu(help_menu)
+        help_act = QAction("Help", self)
+        help_act.setShortcut(QKeySequence("F1"))
+        help_act.triggered.connect(self._show_help)
+        help_menu.addAction(help_act)
+        help_menu.addSeparator()
+        about_act = QAction("About SQLShelf", self)
+        about_act.triggered.connect(self._show_about)
+        help_menu.addAction(about_act)
+
         reveal_act = QAction(
             _icon(QStyle.StandardPixmap.SP_FileDialogDetailedView),
             "Reveal File in Explorer",
@@ -287,8 +298,16 @@ class MainWindow(QMainWindow):
         ew_layout.setSpacing(0)
         ew_layout.addWidget(self._editor)
 
+        # Outer wrapper gives the editor the same 10 px left indent as the
+        # metadata panel content, so the border and buttons align visually.
+        editor_outer = QWidget()
+        eo_layout = QVBoxLayout(editor_outer)
+        eo_layout.setContentsMargins(10, 0, 0, 0)
+        eo_layout.setSpacing(0)
+        eo_layout.addWidget(self._editor_wrapper)
+
         right_layout.addWidget(top_section)
-        right_layout.addWidget(self._editor_wrapper, stretch=1)
+        right_layout.addWidget(editor_outer, stretch=1)
 
         # ── Empty / onboarding state ─────────────────────────────────────────
         self._onboarding = QWidget()
@@ -356,7 +375,7 @@ class MainWindow(QMainWindow):
             lambda: self._edit_toggle_btn.click()
         )
         QShortcut(QKeySequence("Ctrl+N"), self).activated.connect(self.new_query)
-        QShortcut(QKeySequence("Ctrl+K"), self).activated.connect(self.open_command_palette)
+        QShortcut(QKeySequence("Ctrl+P"), self).activated.connect(self.open_command_palette)
         esc = QShortcut(QKeySequence(_Qt.Key.Key_Escape), self)
         esc.setContext(_Qt.ShortcutContext.WindowShortcut)
         esc.activated.connect(self._cancel_edit_mode)
@@ -607,12 +626,7 @@ class MainWindow(QMainWindow):
         self._search_bar.clear()
         self._search_bar.blockSignals(False)
         results: list[SearchResult] = []
-        dbs = (
-            {self._browse_folder: self._known_dbs[self._browse_folder]}
-            if self._browse_folder and self._browse_folder in self._known_dbs
-            else self._known_dbs
-        )
-        for folder, db in dbs.items():
+        for folder, db in self._known_dbs.items():
             try:
                 for r in db.get_favorites():
                     r.folder = folder
@@ -977,6 +991,37 @@ class MainWindow(QMainWindow):
         if body:
             QApplication.clipboard().setText(body)
             self._status_bar.showMessage("SQL body copied to clipboard")
+
+    # ------------------------------------------------------------------
+    # Help / About
+    # ------------------------------------------------------------------
+
+    def _show_help(self) -> None:
+        QMessageBox.information(
+            self,
+            "SQLShelf — Help",
+            "<b>Keyboard shortcuts</b><br><br>"
+            "<b>Ctrl+O</b> — Open Folder<br>"
+            "<b>Ctrl+N</b> — New Query<br>"
+            "<b>Ctrl+D</b> — Duplicate Query<br>"
+            "<b>Ctrl+P</b> — Command Palette<br>"
+            "<b>Ctrl+F</b> — Focus Search<br>"
+            "<b>Ctrl+E</b> — Toggle Edit Mode<br>"
+            "<b>Ctrl+S</b> — Save<br>"
+            "<b>Ctrl+Shift+C</b> — Copy SQL (no frontmatter)<br>"
+            "<b>Esc</b> — Cancel Edit",
+        )
+
+    def _show_about(self) -> None:
+        QMessageBox.about(
+            self,
+            "About SQLShelf",
+            "<b>SQLShelf</b><br><br>"
+            "Open-source SQL query manager.<br>"
+            "Organizes, describes, categorizes and searches SQL files<br>"
+            "by content, table, field or tag.<br><br>"
+            "Author: Raphael Franco",
+        )
 
     # ------------------------------------------------------------------
     # Lifecycle

--- a/sqlshelf/ui/metadata_panel.py
+++ b/sqlshelf/ui/metadata_panel.py
@@ -79,11 +79,11 @@ class MetadataPanel(QWidget):
         )
         self._title_label.setWordWrap(True)
 
-        self._shortcut_hint = QLabel("Ctrl+K")
+        self._shortcut_hint = QLabel("Ctrl+P")
         self._shortcut_hint.setStyleSheet(
             f"color: {TEXT_TERTIARY}; font-size: 9px; padding-right: 4px;"
         )
-        self._shortcut_hint.setToolTip("Command palette (coming soon)")
+        self._shortcut_hint.setToolTip("Command palette")
 
         title_row = QHBoxLayout()
         title_row.setContentsMargins(0, 0, 0, 0)

--- a/sqlshelf/ui/sidebar.py
+++ b/sqlshelf/ui/sidebar.py
@@ -260,7 +260,15 @@ class SidebarWidget(QWidget):
         self._empty_label.setVisible(not has)
         self._folders_list.setVisible(has)
 
+    def _deactivate_nav_btn(self) -> None:
+        if self._active_nav_btn is not None:
+            self._active_nav_btn.setProperty("active", False)
+            self._active_nav_btn.style().unpolish(self._active_nav_btn)
+            self._active_nav_btn.style().polish(self._active_nav_btn)
+            self._active_nav_btn = None
+
     def _on_folder_item_clicked(self, item: QListWidgetItem) -> None:
+        self._deactivate_nav_btn()
         path: Path = item.data(_ROLE_PATH)
         self.folder_selected.emit(path)
 

--- a/sqlshelf/ui/theme/tokens.py
+++ b/sqlshelf/ui/theme/tokens.py
@@ -101,7 +101,7 @@ def app_stylesheet() -> str:
         QToolBar#EditorToolBar {{
             background-color: {CARD};
             border: none;
-            padding: 2px 8px;
+            padding: 2px 8px 2px 10px;
             spacing: 2px;
         }}
         QToolBar#EditorToolBar QPushButton {{
@@ -176,5 +176,44 @@ def app_stylesheet() -> str:
             background-color: rgba(255,255,255,0.08);
             border-radius: 4px;
             border: 1px solid {BORDER_EMPH};
+        }}
+        QPlainTextEdit {{
+            selection-background-color: #264F78;
+            selection-color: #ffffff;
+        }}
+        QMenuBar {{
+            background-color: {BG_APP};
+            color: {TEXT_PRIMARY};
+            border-bottom: 1px solid {BORDER};
+        }}
+        QMenuBar::item {{
+            background: transparent;
+            padding: 4px 8px;
+        }}
+        QMenuBar::item:selected {{
+            background-color: {BORDER_EMPH};
+            color: {TEXT_PRIMARY};
+            border-radius: 3px;
+        }}
+        QMenuBar::item:pressed {{
+            background-color: {CARD};
+            color: {TEXT_PRIMARY};
+        }}
+        QMenu {{
+            background-color: {CARD};
+            border: 1px solid {BORDER_EMPH};
+            color: {TEXT_PRIMARY};
+        }}
+        QMenu::item {{
+            padding: 5px 20px 5px 10px;
+        }}
+        QMenu::item:selected {{
+            background-color: {BORDER_EMPH};
+            color: {TEXT_PRIMARY};
+        }}
+        QMenu::separator {{
+            height: 1px;
+            background-color: {BORDER};
+            margin: 2px 0px;
         }}
     """


### PR DESCRIPTION
- QMenuBar: styled item:selected/pressed with neutral dark tint (BORDER_EMPH) instead of accent green for legible hover on File/View/Help
- QMenu: added drop-down item:selected, separator, and background rules
- QPlainTextEdit: selection-background-color set to #264F78 (VS Code blue) so selected code text is readable instead of bright green
- Sidebar: clicking a folder now deactivates any active BROWSE nav button
- Favorites: always shows favorites from all known folders, not just active folder
- Editor alignment: editor_wrapper wrapped in 10 px left-margin container; toolbar left padding set to 10 px so Edit/Save/Cancel buttons and editor border align with metadata panel title indent
- Shortcut: Ctrl+K → Ctrl+P for command palette (binding + hint label)
- Menu: added Help menu with Help (F1) and About SQLShelf actions