### PR TITLE
fix: update favorite star in list immediately on toggle

### DIFF
--- a/sqlshelf/ui/main_window.py
+++ b/sqlshelf/ui/main_window.py
@@ -1014,6 +1014,7 @@ class MainWindow(QMainWindow):
             is_fav = self._db.toggle_favorite(result.rel_path)
         except Exception:
             return
+        self._query_list.update_favorite(result.rel_path, is_fav)
         if self._current_result and self._current_result.rel_path == result.rel_path:
             self._metadata_panel.set_favorite(is_fav)
         key = "status.added_favorite" if is_fav else "status.removed_favorite"

--- a/sqlshelf/ui/query_list.py
+++ b/sqlshelf/ui/query_list.py
@@ -294,6 +294,16 @@ class QueryListWidget(QWidget):
                 self._list.setCurrentIndex(self._model.index(i, 0))
                 return
 
+    def update_favorite(self, rel_path: str, is_fav: bool) -> None:
+        """Update the favorite star for the item matching *rel_path* in place."""
+        for i, r in enumerate(self._results):
+            if r.rel_path == rel_path:
+                r.is_favorite = is_fav
+                item = self._model.item(i)
+                if item is not None:
+                    item.setData(is_fav, _ROLE_FAVORITE)
+                break
+
     def count(self) -> int:
         return len(self._results)
 


### PR DESCRIPTION
QueryListWidget.update_favorite() patches _ROLE_FAVORITE on the QStandardItem in place so the delegate repaints the star without requiring a full list refresh. Called from _toggle_favorite_for() which covers both the metadata panel star button and the right-click context menu.