### PR TITLE
feat: add Edit menu with Copy Frontmatter Template action

### DIFF
--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -19,6 +19,8 @@
   "menu.about": "About SQLShelf",
   "menu.reveal_in_explorer": "Reveal File in Explorer",
   "menu.open_in_ssms": "Open in SSMS",
+  "menu.edit": "&Edit",
+  "menu.copy_frontmatter_template": "Copy Frontmatter Template",
   "menu.copy_sql": "Copy SQL (no frontmatter)",
   "menu.recent_none": "(none)",
 
@@ -121,6 +123,7 @@
   "status.added_favorite": "Added to favorites: {path}",
   "status.removed_favorite": "Removed from favorites: {path}",
   "status.sql_copied": "SQL body copied to clipboard",
+  "status.frontmatter_template_copied": "Frontmatter template copied to clipboard",
 
   "word.query": "query",
   "word.queries": "queries",
@@ -146,7 +149,7 @@
   "msg.deindex.text": "<b>Remove and deindex:</b><br><br><tt>{path}</tt><br><br>This will delete the search index for this folder and remove it from the sidebar.<br>Your original <tt>.sql</tt> files will <b>not</b> be deleted.<br><br>Are you sure?",
 
   "help.title": "SQLShelf — Help",
-  "help.text": "<b>Keyboard shortcuts</b><br><br><b>Ctrl+O</b> — Open Folder<br><b>Ctrl+N</b> — New Query<br><b>Ctrl+D</b> — Duplicate Query<br><b>Ctrl+P</b> — Command Palette<br><b>Ctrl+F</b> — Focus Search<br><b>Ctrl+E</b> — Toggle Edit Mode<br><b>Ctrl+S</b> — Save<br><b>Ctrl+Shift+C</b> — Copy SQL (no frontmatter)<br><b>Esc</b> — Cancel Edit",
+  "help.text": "<b>Keyboard shortcuts</b><br><br><b>Ctrl+O</b> — Open Folder<br><b>Ctrl+N</b> — New Query<br><b>Ctrl+D</b> — Duplicate Query<br><b>Ctrl+P</b> — Command Palette<br><b>Ctrl+F</b> — Focus Search<br><b>Ctrl+E</b> — Toggle Edit Mode<br><b>Ctrl+S</b> — Save<br><b>Ctrl+Shift+C</b> — Copy SQL (no frontmatter)<br><b>Ctrl+Shift+F</b> — Copy Frontmatter Template<br><b>Esc</b> — Cancel Edit",
 
   "about.title": "About SQLShelf",
   "about.text": "<b>SQLShelf</b><br><br>Open-source SQL query manager.<br>Organizes, describes, categorizes and searches SQL files<br>by content, table, field or tag.<br><br>Author: Raphael Franco"

--- a/locales/es/translation.json
+++ b/locales/es/translation.json
@@ -19,6 +19,8 @@
   "menu.about": "Acerca de SQLShelf",
   "menu.reveal_in_explorer": "Mostrar Archivo en Explorador",
   "menu.open_in_ssms": "Abrir en SSMS",
+  "menu.edit": "&Editar",
+  "menu.copy_frontmatter_template": "Copiar Plantilla de Frontmatter",
   "menu.copy_sql": "Copiar SQL (sin frontmatter)",
   "menu.recent_none": "(ninguno)",
 
@@ -121,6 +123,7 @@
   "status.added_favorite": "Agregado a favoritos: {path}",
   "status.removed_favorite": "Quitado de favoritos: {path}",
   "status.sql_copied": "SQL copiado al portapapeles",
+  "status.frontmatter_template_copied": "Plantilla de frontmatter copiada al portapapeles",
 
   "word.query": "consulta",
   "word.queries": "consultas",

--- a/locales/pt-BR/translation.json
+++ b/locales/pt-BR/translation.json
@@ -19,6 +19,8 @@
   "menu.about": "Sobre o SQLShelf",
   "menu.reveal_in_explorer": "Revelar Arquivo no Explorer",
   "menu.open_in_ssms": "Abrir no SSMS",
+  "menu.edit": "&Editar",
+  "menu.copy_frontmatter_template": "Copiar Modelo de Frontmatter",
   "menu.copy_sql": "Copiar SQL (sem frontmatter)",
   "menu.recent_none": "(nenhum)",
 
@@ -121,6 +123,7 @@
   "status.added_favorite": "Adicionado aos favoritos: {path}",
   "status.removed_favorite": "Removido dos favoritos: {path}",
   "status.sql_copied": "SQL copiado para a área de transferência",
+  "status.frontmatter_template_copied": "Modelo de frontmatter copiado para a área de transferência",
 
   "word.query": "consulta",
   "word.queries": "consultas",

--- a/sqlshelf/ui/main_window.py
+++ b/sqlshelf/ui/main_window.py
@@ -291,6 +291,14 @@ class MainWindow(QMainWindow):
         self._reindex_act.triggered.connect(self.force_reindex)
         self._file_menu.addAction(self._reindex_act)
 
+        self._edit_menu = QMenu(tr("menu.edit"), self)
+        mb.addMenu(self._edit_menu)
+
+        self._copy_frontmatter_template_act = QAction(tr("menu.copy_frontmatter_template"), self)
+        self._copy_frontmatter_template_act.setShortcut(QKeySequence("Ctrl+Shift+F"))
+        self._copy_frontmatter_template_act.triggered.connect(self.copy_frontmatter_template)
+        self._edit_menu.addAction(self._copy_frontmatter_template_act)
+
         self._view_menu = QMenu(tr("menu.view"), self)
         mb.addMenu(self._view_menu)
 
@@ -572,6 +580,8 @@ class MainWindow(QMainWindow):
         self._duplicate_act.setText(tr("menu.duplicate_query"))
         self._recent_menu.setTitle(tr("menu.recent_projects"))
         self._reindex_act.setText(tr("menu.force_reindex"))
+        self._edit_menu.setTitle(tr("menu.edit"))
+        self._copy_frontmatter_template_act.setText(tr("menu.copy_frontmatter_template"))
         self._reveal_act.setText(tr("menu.reveal_in_explorer"))
         self._open_ssms_act.setText(tr("menu.open_in_ssms"))
         self._copy_act.setText(tr("menu.copy_sql"))
@@ -1322,6 +1332,23 @@ class MainWindow(QMainWindow):
         if body:
             QApplication.clipboard().setText(body)
             self._status_bar.showMessage(tr("status.sql_copied"))
+
+    def copy_frontmatter_template(self) -> None:
+        from datetime import date
+
+        today = date.today().isoformat()
+        block = (
+            "/* ---\n"
+            "title: \n"
+            "description: \n"
+            "tags:\n"
+            "  - \n"
+            f"created: {today}\n"
+            f"updated: {today}\n"
+            "--- */"
+        )
+        QApplication.clipboard().setText(block)
+        self._status_bar.showMessage(tr("status.frontmatter_template_copied"))
 
     # ------------------------------------------------------------------
     # Help / About


### PR DESCRIPTION
Adds a new Edit menu (between File and View) containing a 'Copy Frontmatter Template' option (Ctrl+Shift+F). Copies a blank /* --- ... --- */ block with today's date pre-filled so the user can paste it into SSMS or any external editor and fill in the fields. Translations added for en, pt-BR and es.